### PR TITLE
Use SHA256 checksum for lambda archives to assist ESC in checking if deployed functions need to be updated

### DIFF
--- a/.ci/index.ts
+++ b/.ci/index.ts
@@ -147,7 +147,9 @@ export const distributions = distributionRegions.flatMap((region) => {
             key: `${archive.name}/latest.zip`,
             tags: {
                 GitHash: archive.githash,
-            }
+            },
+            // Opt into computing SHA256 checksum so that an archive checksum can be compared directly against a lambda's CodeSha256 to determine if they match
+            checksumAlgorithm: "SHA256",
         }, {...opts, retainOnDelete: true})
     })
 


### PR DESCRIPTION
Use SHA256 checksum for distributed lambda archives so it can be compared directly to a lambda's current [CodeSha256 hash](https://docs.aws.amazon.com/lambda/latest/api/API_FunctionConfiguration.html) to determine if they match. This allows us to easily tell if a lambda function needs to be updated.

See https://github.com/pulumi/pulumi-service/pull/26199#discussion_r2013258418