### PR TITLE
require an external-id for the assumed role

### DIFF
--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -37,7 +37,8 @@ template:
       description: >-
         The ESC environment that is allowed to use the rotation lambda.
         Pulumi will set set an external id with the Pulumi organization and fully qualified ESC environment name when assuming
-        the role to invoke the lambda: `{pulumi organization}/{esc project}/{esc env name}`.
+        the role to invoke the lambda like `{pulumi organization}/{esc project}/{esc env name}`.
+        You can use `*` wildcards if you'd like to match more than one environment.
         See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
       type: string
 
@@ -136,7 +137,7 @@ resources:
               Principal:
                 AWS: ${trustedAccount}
               Condition:
-                StringEquals:
+                StringLike:
                   sts:ExternalId: ${externalId}
       inlinePolicies:
         - policy:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -94,6 +94,7 @@ Allow Pulumi ESC to securely invoke the Lambda
     - Add a ExternalId condition on the role containing the environment slug that will be allowed to use the rotator.
       Pulumi will use an [external id](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
       containing the originating ESC environment name when assuming this role: `{pulumi organization}/{esc project}/{esc env name}`.
+      If you choose, use `StringLike` in the condition to use a wildcard for matching multiple environments.
 
    ```json
    {


### PR DESCRIPTION
Adds an [external id](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html) condition to the assumed role.

The rotator will set this to the originating pulumi environment when assuming the role, which enables the role to be locked down to rotators contained in a _particular_ environment.

See https://github.com/pulumi/esc-rotator-lambdas/pull/2#discussion_r2012528946
