### PR TITLE
[deploy template] Read network config from RDS

### DIFF
--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -6,15 +6,8 @@ template:
     aws:region:
       description: The AWS region to deploy into
       default: us-west-2
-    vpcId:
-      description: The VPC ID where the Lambda will be deployed and can access database instances from
-    subnetIds:
-      description: List of subnet IDs where the Lambda will be deployed (private subnets recommended)
-    databaseSecurityGroupId:
-      description: Security group ID of the database instance the Lambda will access
-    databasePort:
-      description: The port that the database is listening on (default is for MySQL)
-      default: "3306"
+    rdsId:
+      description: The ID of the RDS cluster the lambda will proxy access to.
     lambdaArchiveBucketPrefix:
       description: The name prefix of the regional s3 bucket that contains the lambda code archive
       default: public-esc-rotator-lambdas-production

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,10 +24,7 @@ This Pulumi program deploys the following AWS resources:
 | Parameter                               | Description                                                         |
 |-----------------------------------------|---------------------------------------------------------------------|
 | `aws:region`                            | AWS region for deployment                                           |
-| `vpcId`                                 | VPC where Lambda will be deployed                                   |
-| `subnetIds`                             | Subnets where Lambda will be deployed (private subnets recommended) |
-| `databaseSecurityGroupId`               | Security group ID of the database requiring access                  |
-| `databasePort`                          | Database port (default: 3306 for MySQL)                             |
+| `rdsId`                                 | The ID of the RDS cluster the lambda will proxy access to.          |
 | `externalId`                            | Slug of the environment that is permitted to invoke the rotator     |
 | `lambdaArchiveBucketPrefix`             | Regional S3 bucket prefix containing the Lambda code                |
 | `lambdaArchiveKey`                      | S3 key for the Lambda code archive                                  |

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -5,19 +5,41 @@ import * as aws from "@pulumi/aws";
 const templateConfig = new pulumi.Config("esc-rotator-lambda");
 const awsConfig = new pulumi.Config("aws");
 const awsRegion = awsConfig.require("region");
-const vpcId = templateConfig.require("vpcId");
-const subnetIds = templateConfig.requireObject<string[]>("subnetIds");
-const databaseSecurityGroupId = templateConfig.require("databaseSecurityGroupId");
-const databasePort = templateConfig.requireNumber("databasePort");
+const rdsId = templateConfig.require("rdsId");
 const lambdaArchiveBucketPrefix = templateConfig.require("lambdaArchiveBucketPrefix");
 const lambdaArchiveKey = templateConfig.require("lambdaArchiveKey");
 const lambdaArchiveSigningProfileVersionArn = templateConfig.require("lambdaArchiveSigningProfileVersionArn");
 const trustedAccount = templateConfig.require("trustedAccount");
 const externalId = templateConfig.require("externalId");
 
-// Retrieve code artifact from trusted pulumi bucket 
+// Retrieve reference to current code artifact from trusted pulumi bucket
 const lambdaArchiveBucket = `${lambdaArchiveBucketPrefix}-${awsRegion}`
 const codeArtifact = aws.s3.getObjectOutput({bucket: lambdaArchiveBucket, key: lambdaArchiveKey});
+
+// Introspect RDS to discover network settings
+const database = aws.rds.getClusterOutput({
+    clusterIdentifier: rdsId,
+});
+
+const subnetGroup = aws.rds.getSubnetGroupOutput({
+    name: database.dbSubnetGroupName,
+});
+
+const vpcId = subnetGroup.vpcId;
+let validatedSubnetIds = subnetGroup.subnetIds.apply(async ids => {
+    let subnetIds: string[] = [];
+    for (const id of ids) {
+        await aws.ec2.getSubnet({id: id}, {async: false}).then(
+            _ => subnetIds.push(id),
+            _ => console.log("bad subnet found: "+id),
+        );
+    }
+    return subnetIds;
+});
+
+// going to assume the first security group is the one we need to add an incoming rule to.
+const databaseSecurityGroupId = database.vpcSecurityGroupIds[0];
+const databasePort = database.port;
 
 // Create resources
 const namePrefix = "PulumiEscSecretRotatorLambda-"
@@ -75,7 +97,7 @@ const lambda = new aws.lambda.Function(namePrefix + "Function", {
     handler: "bootstrap",
     role: lambdaExecRole.arn,
     vpcConfig: {
-        subnetIds: subnetIds,
+        subnetIds: validatedSubnetIds,
         securityGroupIds: [lambdaSecurityGroup.id],
     },
 });

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -20,11 +20,11 @@ const codeArtifact = aws.s3.getObjectOutput({bucket: lambdaArchiveBucket, key: l
 const database = aws.rds.getClusterOutput({
     clusterIdentifier: rdsId,
 });
-
 const subnetGroup = aws.rds.getSubnetGroupOutput({
     name: database.dbSubnetGroupName,
 });
-
+const databaseSecurityGroupId = database.vpcSecurityGroupIds[0];
+const databasePort = database.port;
 const vpcId = subnetGroup.vpcId;
 let validatedSubnetIds = subnetGroup.subnetIds.apply(async ids => {
     let subnetIds: string[] = [];
@@ -36,10 +36,6 @@ let validatedSubnetIds = subnetGroup.subnetIds.apply(async ids => {
     }
     return subnetIds;
 });
-
-// going to assume the first security group is the one we need to add an incoming rule to.
-const databaseSecurityGroupId = database.vpcSecurityGroupIds[0];
-const databasePort = database.port;
 
 // Create resources
 const namePrefix = "PulumiEscSecretRotatorLambda-"


### PR DESCRIPTION
Replace the `vpcId`, `subnetIds`, and `securityGroupId` and `databasePort` inputs with an `rdsId`.  

During deploy, we examine the RDS instance and infer the network settings from it for the lambda.
