### PR TITLE
Scope down mysql managing_user permission

### DIFF
--- a/rotators/aws-lambda/mysql/testdata/schema.sql
+++ b/rotators/aws-lambda/mysql/testdata/schema.sql
@@ -20,6 +20,5 @@ GRANT SELECT, INSERT, UPDATE
 
 -- Create Managing User (with privileges to alter the target user)
 CREATE USER IF NOT EXISTS 'managing_user'@'%' IDENTIFIED BY 'manager_password';
-GRANT ALL PRIVILEGES ON credential_rotation_test.* TO 'managing_user'@'%';
+GRANT ALTER ON credential_rotation_test.* TO 'managing_user'@'%';
 GRANT CREATE USER ON *.* TO 'managing_user'@'%';
-GRANT ALTER ON *.* TO 'managing_user'@'%';


### PR DESCRIPTION
### Summary
- Fixes https://github.com/pulumi/pulumi-service/issues/27491
- Scoping down mysql permissions to minimum
- Postgres is already scoped down as much as possible

### Testing
- Tests still succeed as expected