### PR TITLE
Adding option to create example rotator environment

### DIFF
--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -8,6 +8,8 @@ template:
       default: us-west-2
     rdsId:
       description: The ID of the RDS cluster the lambda will proxy access to.
+    environmentName:
+      description: Name of the rotator environment to be created. Format needs to be `myProject/myEnvironment`.
     allowlistedEnvironment:
       description: >-
         The ESC environment(s) that are allowed to use the rotation lambda.
@@ -15,4 +17,4 @@ template:
         the role to invoke the lambda like `{pulumi organization}/{esc project}/{esc env name}`.
         You can use `*` as wildcard to match more than one environment. For example, `myOrg/myProject/*` will match all environments in the `myProject` project. 
         See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
-        If you leave this config empty, an example rotator environment will be created, and its full name will be set as the `allowlistedEnvironment`.
+        If you leave this config empty, allowlist will be scoped down to your organization only, like so `myOrg/*`.

--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -20,10 +20,10 @@ template:
     trustedAccount:
       description: This account will be allowed to invoke the lambda
       default: arn:aws:iam::058607598222:root
-    externalId:
+    allowlistedEnvironment:
       description: >-
-        The ESC environment that is allowed to use the rotation lambda.
-        Pulumi will set set an external id with the Pulumi organization and fully qualified ESC environment name when assuming
+        The ESC environment(s) that are allowed to use the rotation lambda.
+        Pulumi will set fully qualified ESC environment name as an IAM external id when assuming
         the role to invoke the lambda like `{pulumi organization}/{esc project}/{esc env name}`.
-        You can use `*` wildcards if you'd like to match more than one environment.
+        You can use `*` as wildcard to match more than one environment. For example, `myOrg/myProject/*` will match all environments in the `myProject` project. 
         See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html

--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -8,18 +8,6 @@ template:
       default: us-west-2
     rdsId:
       description: The ID of the RDS cluster the lambda will proxy access to.
-    lambdaArchiveBucketPrefix:
-      description: The name prefix of the regional s3 bucket that contains the lambda code archive
-      default: public-esc-rotator-lambdas-production
-    lambdaArchiveKey:
-      description: The key of the lambda archive to deploy
-      default: aws-lambda/latest.zip
-    lambdaArchiveSigningProfileVersionArn:
-      description: This signing profile is used to verify the authenticity of the lambda bundle
-      default: arn:aws:signer:us-west-2:388588623842:/signing-profiles/pulumi_esc_production_20250325212043887700000001/jva5X9nqMa
-    trustedAccount:
-      description: This account will be allowed to invoke the lambda
-      default: arn:aws:iam::058607598222:root
     allowlistedEnvironment:
       description: >-
         The ESC environment(s) that are allowed to use the rotation lambda.
@@ -27,3 +15,4 @@ template:
         the role to invoke the lambda like `{pulumi organization}/{esc project}/{esc env name}`.
         You can use `*` as wildcard to match more than one environment. For example, `myOrg/myProject/*` will match all environments in the `myProject` project. 
         See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
+        If you leave this config empty, an example rotator environment will be created, and its full name will be set as the `allowlistedEnvironment`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,15 +21,11 @@ This Pulumi program deploys the following AWS resources:
 
 ## Configuration Parameters
 
-| Parameter                               |Required | Description                                                         |
-|-----------------------------------------|---------|---------------------------------------------------------------------|
-| `aws:region`                            | Y       | AWS region for deployment                                           |
-| `rdsId`                                 | Y       | The ID of the RDS cluster the lambda will proxy access to.          |
-| `lambdaArchiveBucketPrefix`             | Y       | Regional S3 bucket prefix containing the Lambda code                |
-| `lambdaArchiveKey`                      | Y       | S3 key for the Lambda code archive                                  |
-| `lambdaArchiveSigningProfileVersionArn` | Y       | ARN of signing profile for code verification                        |
-| `trustedAccount`                        | Y       | The Pulumi ESC AWS account allowed to invoke the Lambda             |
-| `allowlistedEnvironment`                | N       | Slug of the environment(s) that are permitted to invoke the rotator. You can use `*` as wildcard - `myOrg/myProject/*` for example. Omit to create an example rotator environment.    |
+| Parameter                                   |Required | Description                                                         |
+|---------------------------------------------|---------|---------------------------------------------------------------------|
+| `aws:region`                                | Y       | AWS region for deployment                                           |
+| `esc-rotator-lambda:rdsId`                  | Y       | The ID of the RDS cluster the lambda will proxy access to.          |
+| `esc-rotator-lambda:allowlistedEnvironment` | N       | Slug of the environment(s) that are permitted to invoke the rotator. You can use `*` as wildcard - `myOrg/myProject/*` for example. Omit to create an example rotator environment.    |
 
 ## Manual Deployment Steps
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,7 +25,8 @@ This Pulumi program deploys the following AWS resources:
 |---------------------------------------------|---------|---------------------------------------------------------------------|
 | `aws:region`                                | Y       | AWS region for deployment                                           |
 | `esc-rotator-lambda:rdsId`                  | Y       | The ID of the RDS cluster the lambda will proxy access to.          |
-| `esc-rotator-lambda:allowlistedEnvironment` | N       | Slug of the environment(s) that are permitted to invoke the rotator. You can use `*` as wildcard - `myOrg/myProject/*` for example. Omit to create an example rotator environment.    |
+| `esc-rotator-lambda:environmentName`        | Y       | Name of the rotator environment to be created. Format needs to be `myProject/myEnvironment`. |
+| `esc-rotator-lambda:allowlistedEnvironment` | N       | Slug of the environment(s) that are permitted to invoke the rotator. You can use `*` as wildcard - `myOrg/myProject/*` for example. |
 
 ## Manual Deployment Steps
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,15 +21,15 @@ This Pulumi program deploys the following AWS resources:
 
 ## Configuration Parameters
 
-| Parameter                               | Description                                                         |
-|-----------------------------------------|---------------------------------------------------------------------|
-| `aws:region`                            | AWS region for deployment                                           |
-| `rdsId`                                 | The ID of the RDS cluster the lambda will proxy access to.          |
-| `externalId`                            | Slug of the environment that is permitted to invoke the rotator     |
-| `lambdaArchiveBucketPrefix`             | Regional S3 bucket prefix containing the Lambda code                |
-| `lambdaArchiveKey`                      | S3 key for the Lambda code archive                                  |
-| `lambdaArchiveSigningProfileVersionArn` | ARN of signing profile for code verification                        |
-| `trustedAccount`                        | The Pulumi ESC AWS account allowed to invoke the Lambda             |
+| Parameter                               |Required | Description                                                         |
+|-----------------------------------------|---------|---------------------------------------------------------------------|
+| `aws:region`                            | Y       | AWS region for deployment                                           |
+| `rdsId`                                 | Y       | The ID of the RDS cluster the lambda will proxy access to.          |
+| `lambdaArchiveBucketPrefix`             | Y       | Regional S3 bucket prefix containing the Lambda code                |
+| `lambdaArchiveKey`                      | Y       | S3 key for the Lambda code archive                                  |
+| `lambdaArchiveSigningProfileVersionArn` | Y       | ARN of signing profile for code verification                        |
+| `trustedAccount`                        | Y       | The Pulumi ESC AWS account allowed to invoke the Lambda             |
+| `allowlistedEnvironment`                | N       | Slug of the environment(s) that are permitted to invoke the rotator. You can use `*` as wildcard - `myOrg/myProject/*` for example. Omit to create an example rotator environment.    |
 
 ## Manual Deployment Steps
 
@@ -89,7 +89,7 @@ Allow Pulumi ESC to securely invoke the Lambda
 1. In IAM, create a new role:
     - Name: `PulumiESCRotatorLambdaInvocationRole`
     - Trust relationship: Allow Pulumi's AWS account id (`058607598222`) to assume this role.
-    - Add a ExternalId condition on the role containing the environment slug that will be allowed to use the rotator.
+    - Add a ExternalId condition on the role containing the `allowlistedEnvironment` slug that will be allowed to use the rotator. See Configuration Parameters for more details.
       Pulumi will use an [external id](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html)
       containing the originating ESC environment name when assuming this role: `{pulumi organization}/{esc project}/{esc env name}`.
       If you choose, use `StringLike` in the condition to use a wildcard for matching multiple environments.

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -1,22 +1,22 @@
 import * as pulumi from "@pulumi/pulumi";
-import * as random from "@pulumi/random";
 import * as pulumiservice from "@pulumi/pulumiservice";
 import * as aws from "@pulumi/aws";
+
+const ARCHIVE_BUCKET_PREFIX = "public-esc-rotator-lambdas-production";
+const ARCHIVE_KEY = "aws-lambda/latest.zip";
+const ARCHIVE_SIGNING_PROFILE_VERSION_ARN = "arn:aws:signer:us-west-2:388588623842:/signing-profiles/pulumi_esc_production_20250325212043887700000001/jva5X9nqMa";
+const TRUSTED_PULUMI_ACCOUNT = "arn:aws:iam::058607598222:root";
 
 // Load configs
 const templateConfig = new pulumi.Config("esc-rotator-lambda");
 const awsConfig = new pulumi.Config("aws");
 const awsRegion = awsConfig.require("region");
 const rdsId = templateConfig.require("rdsId");
-const lambdaArchiveBucketPrefix = templateConfig.require("lambdaArchiveBucketPrefix");
-const lambdaArchiveKey = templateConfig.require("lambdaArchiveKey");
-const lambdaArchiveSigningProfileVersionArn = templateConfig.require("lambdaArchiveSigningProfileVersionArn");
-const trustedAccount = templateConfig.require("trustedAccount");
 const allowlistedEnvironment = templateConfig.get("allowlistedEnvironment") ?? null;
 
 // Retrieve reference to current code artifact from trusted pulumi bucket
-const lambdaArchiveBucket = `${lambdaArchiveBucketPrefix}-${awsRegion}`
-const codeArtifact = aws.s3.getObjectOutput({bucket: lambdaArchiveBucket, key: lambdaArchiveKey});
+const lambdaArchiveBucket = `${ARCHIVE_BUCKET_PREFIX}-${awsRegion}`
+const codeArtifact = aws.s3.getObjectOutput({bucket: lambdaArchiveBucket, key: ARCHIVE_KEY});
 
 // Introspect RDS to discover network settings
 const database = aws.rds.getClusterOutput({
@@ -62,7 +62,7 @@ const namePrefix = "PulumiEscSecretRotatorLambda-"
 const codeSigningConfig = new aws.lambda.CodeSigningConfig(namePrefix + "CodeSigningConfig", {
     description: "Pulumi ESC rotator-lambda signature - https://github.com/pulumi/esc-rotator-lambdas",
     allowedPublishers: {
-        signingProfileVersionArns: [lambdaArchiveSigningProfileVersionArn],
+        signingProfileVersionArns: [ARCHIVE_SIGNING_PROFILE_VERSION_ARN],
     },
     policies: {
         untrustedArtifactOnDeployment: "Enforce",
@@ -125,7 +125,7 @@ const assumedRole = new aws.iam.Role(namePrefix + "InvocationRole", {
             Action: "sts:AssumeRole",
             Effect: "Allow",
             Principal: {
-                AWS: trustedAccount,
+                AWS: TRUSTED_PULUMI_ACCOUNT,
             },
             Condition: {
                 StringLike: {
@@ -164,13 +164,6 @@ const assumedRole = new aws.iam.Role(namePrefix + "InvocationRole", {
     }],
 });
 if (exampleEnvironment) {
-    const randomString = new random.RandomString(namePrefix + "RandomEnvironmentId", {
-        keepers: {
-            allowlistedEnvironment: assumedRole.name,
-        },
-        length: 8,
-        special: false,
-    });
     const rotatorType = databasePort.apply(port => port === 5432 ? "postgres" : "mysql");
     const yaml = pulumi.interpolate
         `values:
@@ -194,8 +187,10 @@ if (exampleEnvironment) {
     const example = new pulumiservice.Environment(namePrefix + "ExampleRotatorEnvironment", {
         organization: exampleEnvironment.organization,
         project: exampleEnvironment.project,
-        name: pulumi.interpolate `${exampleEnvironment.name}-${randomString.result}`,
+        name: pulumi.interpolate `${exampleEnvironment.name}-${pulumi.getStack()}`,
         yaml: yaml,
+    }, {
+        deleteBeforeReplace: true,
     })
 }
 

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -7,6 +7,8 @@
 	"dependencies": {
 		"@pulumi/aws": "6.69.0",
 		"@pulumi/pulumi": "^3.0.0",
+		"@pulumi/pulumiservice": "^0.29.1",
+		"@pulumi/random": "^4.18.0",
 		"typescript": "^4.0.0"
 	}
 }

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -8,7 +8,6 @@
 		"@pulumi/aws": "6.69.0",
 		"@pulumi/pulumi": "^3.0.0",
 		"@pulumi/pulumiservice": "^0.29.1",
-		"@pulumi/random": "^4.18.0",
 		"typescript": "^4.0.0"
 	}
 }

--- a/deploy/yarn.lock
+++ b/deploy/yarn.lock
@@ -418,13 +418,6 @@
   dependencies:
     "@pulumi/pulumi" "^3.0.0"
 
-"@pulumi/random@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/random/-/random-4.18.0.tgz#d04d3a5530ad12fc080a52f286f40fcc9ca1a987"
-  integrity sha512-6joE5/jhadtWmwuMh3YtDB1kA3G4pDLVhk+l5mSxe/kuf+ejQ1w+LnfbpRi9iinwPl2AqzfDp9IheksTxIwzFA==
-  dependencies:
-    "@pulumi/pulumi" "^3.142.0"
-
 "@sigstore/bundle@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-2.3.2.tgz#ad4dbb95d665405fd4a7a02c8a073dbd01e4e95e"

--- a/deploy/yarn.lock
+++ b/deploy/yarn.lock
@@ -411,6 +411,20 @@
     tmp "^0.2.1"
     upath "^1.1.0"
 
+"@pulumi/pulumiservice@^0.29.1":
+  version "0.29.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumiservice/-/pulumiservice-0.29.1.tgz#ade8ddaf63ae829bf8ffa2c27635b9ea7402904b"
+  integrity sha512-6AF7mn8sTyxbJiVStQ1BRoH8Xq5eMjoPrMT2IbcZx4BhMJ1Ng38LN1vbLB6eYVqcZbQyZWVOCayC9qsGN4Q+pA==
+  dependencies:
+    "@pulumi/pulumi" "^3.0.0"
+
+"@pulumi/random@^4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/random/-/random-4.18.0.tgz#d04d3a5530ad12fc080a52f286f40fcc9ca1a987"
+  integrity sha512-6joE5/jhadtWmwuMh3YtDB1kA3G4pDLVhk+l5mSxe/kuf+ejQ1w+LnfbpRi9iinwPl2AqzfDp9IheksTxIwzFA==
+  dependencies:
+    "@pulumi/pulumi" "^3.142.0"
+
 "@sigstore/bundle@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-2.3.2.tgz#ad4dbb95d665405fd4a7a02c8a073dbd01e4e95e"


### PR DESCRIPTION
### Note: Merge only after https://github.com/pulumi/pulumi-service/pull/27520 is in prod

### Summary
- Fixes https://github.com/pulumi/pulumi-service/issues/27379 and https://github.com/pulumi/pulumi-service/issues/27427
- Renaming `externalId` to `allowlistedEnvironment`
- Adds logic to create an example environment if `allowlistedEnvironment` is not provided (and fills in allowlist to only be that example environment). Otherwise, if `allowlistedEnvironment` is provided, does not do anything new.

### Testing
- Manually tested, the environment was able to rotate right away (my users match the default values)