### PR TITLE
Adding separate environment for managing credentials

### DIFF
--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -10,6 +10,10 @@ template:
       description: The ID of the RDS cluster the lambda will proxy access to.
     environmentName:
       description: Name of the rotator environment to be created. Format needs to be `myProject/myEnvironment`.
+    managingCredsEnvironmentName:
+      description: >-
+        Name of the managing credentials environment to be created. Format needs to be `myProject/myEnvironment`.
+        You can skip specifying this one, and it will be derived from `environmentName`.
     allowlistedEnvironment:
       description: >-
         The ESC environment(s) that are allowed to use the rotation lambda.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,12 +21,13 @@ This Pulumi program deploys the following AWS resources:
 
 ## Configuration Parameters
 
-| Parameter                                   |Required | Description                                                         |
-|---------------------------------------------|---------|---------------------------------------------------------------------|
-| `aws:region`                                | Y       | AWS region for deployment                                           |
-| `esc-rotator-lambda:rdsId`                  | Y       | The ID of the RDS cluster the lambda will proxy access to.          |
-| `esc-rotator-lambda:environmentName`        | Y       | Name of the rotator environment to be created. Format needs to be `myProject/myEnvironment`. |
-| `esc-rotator-lambda:allowlistedEnvironment` | N       | Slug of the environment(s) that are permitted to invoke the rotator. You can use `*` as wildcard - `myOrg/myProject/*` for example. |
+| Parameter                                        |Required | Description                                                         |
+|--------------------------------------------------|---------|---------------------------------------------------------------------|
+| `aws:region`                                     | Y       | AWS region for deployment                                           |
+| `esc-rotator-lambda:rdsId`                       | Y       | The ID of the RDS cluster the lambda will proxy access to.          |
+| `esc-rotator-lambda:environmentName`             | Y       | Name of the rotator environment to be created. Format needs to be `myProject/myEnvironment`. |
+| `esc-rotator-lambda:managingCredsEnvironmentName`| N       | Name of the managing credentials environment to be created. Format needs to be `myProject/myEnvironment`. You can skip specifying this one, and it will be derived from `environmentName`. |
+| `esc-rotator-lambda:allowlistedEnvironment`      | N       | Slug of the environment(s) that are permitted to invoke the rotator. You can use `*` as wildcard - `myOrg/myProject/*` for example. |
 
 ## Manual Deployment Steps
 


### PR DESCRIPTION
### Summary
- Adding managing credentials into separate environment (to promote best practice of minimum access scope)
- Adding managing credentials environment name into parameters, or let it be derived

### Testing
- Manually tested pulumi destroy and up