### PR TITLE
Reworked lambda to use new OIDC way of loggging in

### DIFF
--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -14,11 +14,7 @@ template:
       description: >-
         Name of the managing credentials environment to be created. Format needs to be `myProject/myEnvironment`.
         You can skip specifying this one, and it will be derived from `environmentName`.
-    allowlistedEnvironment:
+    backendUrl:
+      default: https://api.pulumi.com
       description: >-
-        The ESC environment(s) that are allowed to use the rotation lambda.
-        Pulumi will set fully qualified ESC environment name as an IAM external id when assuming
-        the role to invoke the lambda like `{pulumi organization}/{esc project}/{esc env name}`.
-        You can use `*` as wildcard to match more than one environment. For example, `myOrg/myProject/*` will match all environments in the `myProject` project. 
-        See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
-        If you leave this config empty, allowlist will be scoped down to your organization only, like so `myOrg/*`.
+        The Pulumi backend URL. Unless you use Pulumi self-hosted, leave this as default.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -27,7 +27,7 @@ This Pulumi program deploys the following AWS resources:
 | `esc-rotator-lambda:rdsId`                       | Y       | The ID of the RDS cluster the lambda will proxy access to.          |
 | `esc-rotator-lambda:environmentName`             | Y       | Name of the rotator environment to be created. Format needs to be `myProject/myEnvironment`. |
 | `esc-rotator-lambda:managingCredsEnvironmentName`| N       | Name of the managing credentials environment to be created. Format needs to be `myProject/myEnvironment`. You can skip specifying this one, and it will be derived from `environmentName`. |
-| `esc-rotator-lambda:allowlistedEnvironment`      | N       | Slug of the environment(s) that are permitted to invoke the rotator. You can use `*` as wildcard - `myOrg/myProject/*` for example. |
+| `esc-rotator-lambda:backendUrl`                  | N       | The Pulumi backend URL. Unless you use Pulumi self-hosted, leave this as default. |
 
 ## Manual Deployment Steps
 


### PR DESCRIPTION
### Summary
- Adding logic to create OIDC provider (if doesn't exist)
- Rework lambda trust policy to use OIDC identity and login object instead of direct role assumption
- Updated environment yamls to match new format accepting aws login object

### Testing
- Tested on review stack and prod